### PR TITLE
Initial type abstraction api proposal

### DIFF
--- a/hibernate-jpql-parser/src/main/java/org/hibernate/sql/ast/AnyTypeDescriptor.java
+++ b/hibernate-jpql-parser/src/main/java/org/hibernate/sql/ast/AnyTypeDescriptor.java
@@ -1,0 +1,7 @@
+package org.hibernate.sql.ast;
+
+/**
+ * @author Steve Ebersole
+ */
+public class AnyTypeDescriptor {
+}

--- a/hibernate-jpql-parser/src/main/java/org/hibernate/sql/ast/BasicTypeDescriptor.java
+++ b/hibernate-jpql-parser/src/main/java/org/hibernate/sql/ast/BasicTypeDescriptor.java
@@ -1,0 +1,7 @@
+package org.hibernate.sql.ast;
+
+/**
+ * @author Steve Ebersole
+ */
+public interface BasicTypeDescriptor {
+}

--- a/hibernate-jpql-parser/src/main/java/org/hibernate/sql/ast/CollectionTypeDescriptor.java
+++ b/hibernate-jpql-parser/src/main/java/org/hibernate/sql/ast/CollectionTypeDescriptor.java
@@ -1,0 +1,7 @@
+package org.hibernate.sql.ast;
+
+/**
+ * @author Steve Ebersole
+ */
+public interface CollectionTypeDescriptor {
+}

--- a/hibernate-jpql-parser/src/main/java/org/hibernate/sql/ast/CompositeTypeDescriptor.java
+++ b/hibernate-jpql-parser/src/main/java/org/hibernate/sql/ast/CompositeTypeDescriptor.java
@@ -1,0 +1,7 @@
+package org.hibernate.sql.ast;
+
+/**
+ * @author Steve Ebersole
+ */
+public interface CompositeTypeDescriptor {
+}

--- a/hibernate-jpql-parser/src/main/java/org/hibernate/sql/ast/EntityTypeDescriptor.java
+++ b/hibernate-jpql-parser/src/main/java/org/hibernate/sql/ast/EntityTypeDescriptor.java
@@ -1,0 +1,7 @@
+package org.hibernate.sql.ast;
+
+/**
+ * @author Steve Ebersole
+ */
+public interface EntityTypeDescriptor {
+}

--- a/hibernate-jpql-parser/src/main/java/org/hibernate/sql/ast/TypeDescriptor.java
+++ b/hibernate-jpql-parser/src/main/java/org/hibernate/sql/ast/TypeDescriptor.java
@@ -1,0 +1,7 @@
+package org.hibernate.sql.ast;
+
+/**
+ * @author Steve Ebersole
+ */
+public interface TypeDescriptor {
+}


### PR DESCRIPTION
An initial proposal for a "type abstraction" api, to start discussion.  

Majority of the contract here is based on the ORM  interface JavaTypeDescriptor rather than Type (ORM) and GridType (OGM); that was a conscious decision because I believe the JavaTypeDescriptor is a better contract.  However, that does open up a concern in that neither Type nor GridType implement those methods atm.  We can substitute the methods as defined in Type/GridType if we all deem that is easier.
