### PR TITLE
HQLPARSER-43 Incorrect handling of string literals containing single quo...

### DIFF
--- a/parser/src/main/antlr/org/hibernate/hql/ast/origin/hql/parse/HQLLexer.g
+++ b/parser/src/main/antlr/org/hibernate/hql/ast/origin/hql/parse/HQLLexer.g
@@ -235,7 +235,7 @@ CHARACTER_LITERAL
 
 STRING_LITERAL
 	:	'"' ( ESCAPE_SEQUENCE | ~('\\'|'"') )* '"' {setText(getText().substring(1, getText().length()-1));}
-	|	('\'' ( ESCAPE_SEQUENCE | ~('\\'|'\'') )* '\'')+ {setText(getText().substring(1, getText().length()-1));}
+	|	('\'' ( ESCAPE_SEQUENCE | ~('\\'|'\'') )* '\'')+ {setText(getText().substring(1, getText().length()-1).replace("''", "'"));}
 	;
 
 fragment

--- a/parser/src/test/java/org/hibernate/hql/test/tree/ParsingTest.java
+++ b/parser/src/test/java/org/hibernate/hql/test/tree/ParsingTest.java
@@ -80,6 +80,13 @@ public class ParsingTest {
 			"(QUERY (QUERY_SPEC (SELECT_FROM (from (PERSISTER_SPACE (ENTITY_PERSISTER_REF com.acme.EntityName e))) (SELECT (SELECT_LIST (SELECT_ITEM e)))) (where (= (PATH (. e name)) (CONST_STRING_VALUE same)))))");
 	}
 
+	@Test
+	public void testStringLiteralSingleQuoteEscape() {
+		//generated alias:
+		assertTreeParsed( null, "from com.acme.EntityName e where e.name = 'Jack Daniel''s Old No. 7'",
+			"(QUERY (QUERY_SPEC (SELECT_FROM (from (PERSISTER_SPACE (ENTITY_PERSISTER_REF com.acme.EntityName e))) (SELECT (SELECT_LIST (SELECT_ITEM e)))) (where (= (PATH (. e name)) (CONST_STRING_VALUE Jack Daniel's Old No. 7)))))");
+	}
+
 	private void assertTreeParsed(ParserContext context, String input, String treeExpectation) {
 		HQLLexer lexed = new HQLLexer( new ANTLRStringStream( input ) );
 		CommonTokenStream tokens = new CommonTokenStream( lexed );


### PR DESCRIPTION
...tes

Single quotes embedded in a string are actually represented by two single quotes.
They are properly recognized by the lexer grammar but the output token should contain a single quote not two. (See spec doc Java Persistence 2.1, Final Release section 4.6.1)

Jira: https://hibernate.atlassian.net/browse/HQLPARSER-43

(this fix is needed for 1.0.x too, backport is in anistor:HQLPARSER-43_10x) 
