### PR TITLE
HQLPARSER-53 Join on embedded collections

### DIFF
--- a/lucene/src/main/java/org/hibernate/hql/lucene/internal/LuceneQueryRendererDelegate.java
+++ b/lucene/src/main/java/org/hibernate/hql/lucene/internal/LuceneQueryRendererDelegate.java
@@ -33,6 +33,8 @@ import org.hibernate.hql.ast.spi.SingleEntityQueryBuilder;
 import org.hibernate.hql.ast.spi.SingleEntityQueryRendererDelegate;
 import org.hibernate.hql.lucene.LuceneQueryParsingResult;
 import org.hibernate.hql.lucene.internal.builder.LucenePropertyHelper;
+import org.hibernate.hql.lucene.internal.logging.Log;
+import org.hibernate.hql.lucene.internal.logging.LoggerFactory;
 import org.hibernate.search.bridge.FieldBridge;
 import org.hibernate.search.bridge.builtin.NumericFieldBridge;
 import org.hibernate.search.engine.ProjectionConstants;
@@ -43,6 +45,8 @@ import org.hibernate.search.engine.ProjectionConstants;
  * @author Gunnar Morling
  */
 public class LuceneQueryRendererDelegate extends SingleEntityQueryRendererDelegate<Query, LuceneQueryParsingResult> {
+
+	private static final Log log = LoggerFactory.make();
 
 	private final LucenePropertyHelper propertyHelper;
 
@@ -98,11 +102,26 @@ public class LuceneQueryRendererDelegate extends SingleEntityQueryRendererDelega
 				projections.add( ProjectionConstants.THIS );
 			}
 			else {
-				projections.add( propertyPath.asStringPathWithoutAlias() );
+				List<String> names = resolveAlias( propertyPath );
+				projections.add( join( names ) );
 			}
 		}
 		else {
 			this.propertyPath = propertyPath;
 		}
+	}
+
+	private String join(List<String> names) {
+		StringBuilder projection = new StringBuilder();
+		for ( String name : names ) {
+			projection.append( "." );
+			projection.append( name );
+		}
+		return projection.substring( 1 );
+	}
+
+	@Override
+	public void aliasNotFound(String alias) {
+		throw log.getUnknownAliasException( alias );
 	}
 }

--- a/lucene/src/main/java/org/hibernate/hql/lucene/internal/LuceneQueryRendererDelegate.java
+++ b/lucene/src/main/java/org/hibernate/hql/lucene/internal/LuceneQueryRendererDelegate.java
@@ -119,9 +119,4 @@ public class LuceneQueryRendererDelegate extends SingleEntityQueryRendererDelega
 		}
 		return projection.substring( 1 );
 	}
-
-	@Override
-	public void aliasNotFound(String alias) {
-		throw log.getUnknownAliasException( alias );
-	}
 }

--- a/lucene/src/main/java/org/hibernate/hql/lucene/internal/builder/ClassBasedLucenePropertyHelper.java
+++ b/lucene/src/main/java/org/hibernate/hql/lucene/internal/builder/ClassBasedLucenePropertyHelper.java
@@ -99,8 +99,9 @@ public class ClassBasedLucenePropertyHelper extends LucenePropertyHelper {
 			}
 		}
 
-		return metadata.getPropertyMetadataForProperty( propertyPath[propertyPath.length - 1] ) != null
-				|| getEmbeddedTypeMetadata( metadata.getEmbeddedTypeMetadata(), propertyPath[propertyPath.length - 1] ) != null;
+		PropertyMetadata propertyMetadataForProperty = metadata.getPropertyMetadataForProperty( propertyPath[propertyPath.length - 1] );
+		boolean b = getEmbeddedTypeMetadata( metadata.getEmbeddedTypeMetadata(), propertyPath[propertyPath.length - 1] ) != null;
+		return propertyMetadataForProperty != null || b;
 	}
 
 	private TypeMetadata getLeafTypeMetadata(Class<?> type, String... propertyPath) {

--- a/lucene/src/main/java/org/hibernate/hql/lucene/internal/builder/LucenePropertyHelper.java
+++ b/lucene/src/main/java/org/hibernate/hql/lucene/internal/builder/LucenePropertyHelper.java
@@ -58,14 +58,14 @@ public abstract class LucenePropertyHelper implements PropertyHelper {
 	@Override
 	public Object convertToPropertyType(String entityType, List<String> propertyPath, String value) {
 		final FieldBridge bridge = getFieldBridge( entityType, propertyPath);
-		return convertToPropertyType(entityType, propertyPath, value, bridge);
+		return convertToPropertyType( entityType, propertyPath, value, bridge );
 	}
 
 	private Object convertToPropertyType(String entityType, List<String> propertyPath, String value, FieldBridge bridge) {
 		//Order matters! Some types are subclasses of others
 		//TODO expose something in Hibernate Search so that we can avoid this horrible code
 		if ( bridge instanceof NullEncodingTwoWayFieldBridge ) {
-			return convertToPropertyType(entityType, propertyPath, value, ( (NullEncodingTwoWayFieldBridge) bridge ).unwrap() );
+			return convertToPropertyType( entityType, propertyPath, value, ( (NullEncodingTwoWayFieldBridge) bridge ).unwrap() );
 		}
 		else if ( bridge instanceof TwoWayString2FieldBridgeAdaptor ) {
 			return ( (TwoWayString2FieldBridgeAdaptor) bridge ).unwrap().stringToObject( value );

--- a/lucene/src/test/java/org/hibernate/hql/lucene/test/LuceneQueryParsingTestBase.java
+++ b/lucene/src/test/java/org/hibernate/hql/lucene/test/LuceneQueryParsingTestBase.java
@@ -353,6 +353,23 @@ public abstract class LuceneQueryParsingTestBase {
 				"-name:_null_ *:*" );
 	}
 
+	@Test
+	public void shouldCreateCollectionOfEmbeddedableQuery() {
+		assertLuceneQuery(
+				"select e from IndexedEntity e JOIN e.contactDetails d WHERE d.email = 'mym@il.it' ",
+				"contactDetails.email:mym@il.it" );
+	}
+
+	@Test
+	public void shouldCreateCollectionOfEmbeddedableInEmbeddedQuery() {
+		assertLuceneQuery(
+				"SELECT e FROM IndexedEntity e "
+						+ " JOIN e.contactDetails d"
+						+ " JOIN d.address.alternatives as a "
+				+ "WHERE a.postCode = '28921' ",
+				"contactDetails.address.alternatives.postCode:28921" );
+	}
+
 	private void assertLuceneQuery(String queryString, String expectedLuceneQuery) {
 		assertLuceneQuery( queryString, null, expectedLuceneQuery );
 	}

--- a/lucene/src/test/java/org/hibernate/hql/lucene/test/UntypedLuceneQueryParsingTest.java
+++ b/lucene/src/test/java/org/hibernate/hql/lucene/test/UntypedLuceneQueryParsingTest.java
@@ -119,6 +119,8 @@ public class UntypedLuceneQueryParsingTest extends LuceneQueryParsingTestBase {
 			indexedEntityBridges.put( "title", new TwoWayString2FieldBridgeAdaptor( new StringBridge() ) );
 			indexedEntityBridges.put( "author", new NullEncodingFieldBridge( new String2FieldBridgeAdaptor( DefaultStringBridge.INSTANCE ), "_null_" ) );
 			indexedEntityBridges.put( "author.name", new TwoWayString2FieldBridgeAdaptor( new StringBridge() ) );
+			indexedEntityBridges.put( "contactDetails.email", new TwoWayString2FieldBridgeAdaptor( new StringBridge() ) );
+			indexedEntityBridges.put( "contactDetails.address.alternatives.postCode", new TwoWayString2FieldBridgeAdaptor( new StringBridge() ) );
 
 			bridgesByType.put( "IndexedEntity", indexedEntityBridges );
 		}

--- a/lucene/src/test/java/org/hibernate/hql/lucene/test/model/ContactAddress.java
+++ b/lucene/src/test/java/org/hibernate/hql/lucene/test/model/ContactAddress.java
@@ -1,0 +1,55 @@
+/*
+ * Hibernate OGM, Domain model persistence for NoSQL datastores
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.hql.lucene.test.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.ElementCollection;
+import javax.persistence.Embeddable;
+
+import org.hibernate.search.annotations.Analyze;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.IndexedEmbedded;
+
+/**
+ * @author Davide D'Alto
+ */
+@Embeddable
+public class ContactAddress {
+
+	private String address;
+	private String postCode;
+	private List<ContactAddress> alternatives = new ArrayList<ContactAddress>();
+
+	@Field(analyze = Analyze.NO)
+	public String getAddress() {
+		return address;
+	}
+
+	public void setAddress(String address) {
+		this.address = address;
+	}
+
+	@Field(analyze = Analyze.NO)
+	public String getPostCode() {
+		return postCode;
+	}
+
+	public void setPostCode(String postCode) {
+		this.postCode = postCode;
+	}
+
+	@IndexedEmbedded(depth = 3)
+	public List<ContactAddress> getAlternatives() {
+		return alternatives;
+	}
+
+	public void setAlternatives(List<ContactAddress> alternatives) {
+		this.alternatives = alternatives;
+	}
+}

--- a/lucene/src/test/java/org/hibernate/hql/lucene/test/model/ContactDetail.java
+++ b/lucene/src/test/java/org/hibernate/hql/lucene/test/model/ContactDetail.java
@@ -1,0 +1,67 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.hibernate.hql.lucene.test.model;
+
+import javax.persistence.Embeddable;
+
+import org.hibernate.search.annotations.Analyze;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.IndexedEmbedded;
+
+/**
+ * @author Davide D'Alto
+ */
+@Embeddable
+public class ContactDetail {
+
+	private String email;
+	private String phoneNumber;
+	private ContactAddress address;
+
+	@Field( analyze = Analyze.NO )
+	public String getEmail() {
+		return email;
+	}
+
+	public void setEmail(String email) {
+		this.email = email;
+	}
+
+	@Field( analyze = Analyze.NO )
+	public String getPhoneNumber() {
+		return phoneNumber;
+	}
+
+	public void setPhoneNumber(String phoneNumber) {
+		this.phoneNumber = phoneNumber;
+	}
+
+	@IndexedEmbedded	
+	public ContactAddress getAddress() {
+		return address;
+	}
+
+	
+	public void setAddress(ContactAddress address) {
+		this.address = address;
+	}
+
+}

--- a/lucene/src/test/java/org/hibernate/hql/lucene/test/model/IndexedEntity.java
+++ b/lucene/src/test/java/org/hibernate/hql/lucene/test/model/IndexedEntity.java
@@ -20,7 +20,11 @@
  */
 package org.hibernate.hql.lucene.test.model;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.persistence.CascadeType;
+import javax.persistence.ElementCollection;
 import javax.persistence.Id;
 import javax.persistence.OneToOne;
 
@@ -41,6 +45,8 @@ public class IndexedEntity {
 	private String text;
 	private String title;
 	private Author author;
+	private List<ContactDetail> contactDetails = new ArrayList<ContactDetail>();
+	private List<ContactDetail> alternativeContactDetails = new ArrayList<ContactDetail>();
 
 	@Id
 	public String getId() {
@@ -95,5 +101,25 @@ public class IndexedEntity {
 
 	public void setAuthor(Author author) {
 		this.author = author;
+	}
+
+	@ElementCollection
+	@IndexedEmbedded
+	public List<ContactDetail> getContactDetails() {
+		return contactDetails;
+	}
+
+	public void setContactDetails(List<ContactDetail> contactDetails) {
+		this.contactDetails = contactDetails;
+	}
+
+	@ElementCollection
+	@IndexedEmbedded
+	public List<ContactDetail> getAlternativeContactDetails() {
+		return alternativeContactDetails;
+	}
+
+	public void setAlternativeContactDetails(List<ContactDetail> alternativeContactDetails) {
+		this.alternativeContactDetails = alternativeContactDetails;
 	}
 }

--- a/parser/src/main/antlr/org/hibernate/hql/ast/origin/hql/parse/HQLParser.g
+++ b/parser/src/main/antlr/org/hibernate/hql/ast/origin/hql/parse/HQLParser.g
@@ -390,7 +390,7 @@ qualifiedJoin
 	|	propertyFetch? withClause?
 	)
 	-> {isEntityReference}? ^(PERSISTER_JOIN[$join_key.start,"persister-join"] nonCrossJoinType ^(ENTITY_PERSISTER_REF ENTITY_NAME<EntityNameTree>[$path.start, $path.text, entityNames] aliasClause?) ^(on_key logicalExpression))
-	-> ^(PROPERTY_JOIN[$join_key.start, "property-join"] nonCrossJoinType fetch_key? aliasClause? propertyFetch? ^(PROPERTY_REFERENCE path) withClause?)
+	-> ^(PROPERTY_JOIN[$join_key.start, "property-join"] nonCrossJoinType fetch_key? aliasClause? propertyFetch? ^(PATH path) withClause?)
 	;
 
 withClause

--- a/parser/src/main/antlr/org/hibernate/hql/ast/origin/hql/resolve/GeneratedHQLResolver.g
+++ b/parser/src/main/antlr/org/hibernate/hql/ast/origin/hql/resolve/GeneratedHQLResolver.g
@@ -160,9 +160,14 @@ persisterSpaceRoot
 joins
 	:	^(PROPERTY_JOIN jt=joinType ft=FETCH? an=ALIAS_NAME pf=PROP_FETCH?
 		{	delegate.pushFromStrategy($jt.joinType, $ft, $pf, $an );	}
-		(collectionExpression|propertyReference) withClause?)
+		(joinProperty[$an]) withClause?)
 		{	delegate.popStrategy();	}
 	|	^(PERSISTER_JOIN joinType persisterSpaceRoot onClause?)
+	;
+
+joinProperty [Tree an]
+	: collectionExpression
+	| joinPropertyReference[$an]
 	;
 
 withClause
@@ -519,6 +524,11 @@ entityName
 
 propertyReference
 	:	^(PROPERTY_REFERENCE propertyReferencePath)
+	;
+
+joinPropertyReference [Tree an]
+	@after {delegate.registerJoinAlias($an, $ret.retPath); }
+	: ^(PATH ret=propertyReferencePath) -> ^(PATH<node=PropertyPathTree>[$PATH, $ret.retPath] propertyReferencePath)
 	;
 
 propertyReferencePath returns [PropertyPath retPath]

--- a/parser/src/main/antlr/org/hibernate/hql/ast/render/QueryRenderer.g
+++ b/parser/src/main/antlr/org/hibernate/hql/ast/render/QueryRenderer.g
@@ -159,7 +159,7 @@ persisterSpaceRoot
 joins
 	:	^(PROPERTY_JOIN jt=joinType ft=FETCH? an=ALIAS_NAME pf=PROP_FETCH?
 		{	delegate.pushFromStrategy($jt.joinType, $ft, $pf, $an );	}
-		(collectionExpression|propertyReference) withClause?)
+		(collectionExpression|joinPropertyReference[$an]) withClause?)
 		{	delegate.popStrategy();	}
 	|	^(PERSISTER_JOIN joinType persisterSpaceRoot onClause?)
 	;
@@ -517,8 +517,12 @@ propertyReference
 	:	^(PROPERTY_REFERENCE propertyReferencePath)
 	;
 
+joinPropertyReference[Tree alias]
+	: ^(PATH propertyReferencePath) { delegate.registerJoinAlias( $alias, ( (PropertyPathTree) $PATH ).getPropertyPath() ); }
+	;
+
 propertyReferencePath
-	: 	{delegate.isUnqualifiedPropertyReference()}? unqualifiedPropertyReference
+	: {delegate.isUnqualifiedPropertyReference()}? unqualifiedPropertyReference
 	|	pathedPropertyReference
 	|	terminalIndexOperation
 	;

--- a/parser/src/main/java/org/hibernate/hql/ast/origin/hql/resolve/path/PropertyPath.java
+++ b/parser/src/main/java/org/hibernate/hql/ast/origin/hql/resolve/path/PropertyPath.java
@@ -34,15 +34,7 @@ import org.hibernate.hql.internal.util.Strings;
  */
 public class PropertyPath {
 
-	private final LinkedList<PathedPropertyReferenceSource> path;
-
-	public PropertyPath() {
-		path = new LinkedList<PathedPropertyReferenceSource>();
-	}
-
-	public PropertyPath(PropertyPath path) {
-		this.path = path.path;
-	}
+	private final LinkedList<PathedPropertyReferenceSource> path = new LinkedList<PathedPropertyReferenceSource>();
 
 	public void appendNode(PathedPropertyReferenceSource property) {
 		path.add( property );
@@ -50,6 +42,10 @@ public class PropertyPath {
 
 	public PathedPropertyReferenceSource getLastNode() {
 		return path.getLast();
+	}
+
+	public PathedPropertyReferenceSource getFirstNode() {
+		return path.getFirst();
 	}
 
 	public List<PathedPropertyReferenceSource> getNodes() {

--- a/parser/src/main/java/org/hibernate/hql/ast/spi/QueryRendererDelegate.java
+++ b/parser/src/main/java/org/hibernate/hql/ast/spi/QueryRendererDelegate.java
@@ -35,6 +35,8 @@ public interface QueryRendererDelegate<T> {
 
 	void registerPersisterSpace(Tree entityName, Tree alias);
 
+	void registerJoinAlias(Tree alias, PropertyPath path);
+
 	boolean isUnqualifiedPropertyReference();
 
 	boolean isPersisterReferenceAlias();

--- a/parser/src/main/java/org/hibernate/hql/ast/spi/QueryResolverDelegate.java
+++ b/parser/src/main/java/org/hibernate/hql/ast/spi/QueryResolverDelegate.java
@@ -34,6 +34,8 @@ public interface QueryResolverDelegate {
 
 	void registerPersisterSpace(Tree entityName, Tree alias);
 
+	void registerJoinAlias(Tree alias, PropertyPath path);
+
 	boolean isUnqualifiedPropertyReference();
 
 	PathedPropertyReferenceSource normalizeUnqualifiedPropertyReference(Tree property);

--- a/parser/src/main/java/org/hibernate/hql/ast/spi/SingleEntityQueryRendererDelegate.java
+++ b/parser/src/main/java/org/hibernate/hql/ast/spi/SingleEntityQueryRendererDelegate.java
@@ -30,6 +30,8 @@ import org.antlr.runtime.tree.Tree;
 import org.hibernate.hql.ast.common.JoinType;
 import org.hibernate.hql.ast.origin.hql.resolve.path.PropertyPath;
 import org.hibernate.hql.ast.spi.predicate.ComparisonPredicate.Type;
+import org.hibernate.hql.internal.logging.Log;
+import org.hibernate.hql.internal.logging.LoggerFactory;
 
 /**
  * This extends the ANTLR generated AST walker to transform a parsed tree
@@ -50,6 +52,8 @@ import org.hibernate.hql.ast.spi.predicate.ComparisonPredicate.Type;
  * @author Gunnar Morling
  */
 public abstract class SingleEntityQueryRendererDelegate<Q, R> implements QueryRendererDelegate<R> {
+
+	private static final Log log = LoggerFactory.make();
 
 	protected static final String SORT_ASC_SPEC = "asc";
 
@@ -340,5 +344,7 @@ public abstract class SingleEntityQueryRendererDelegate<Q, R> implements QueryRe
 		}
 	}
 
-	public abstract void aliasNotFound(String alias);
+	public void aliasNotFound(String alias) {
+		throw log.getUnknownAliasException( alias );
+	}
 }

--- a/parser/src/main/java/org/hibernate/hql/ast/spi/SingleEntityQueryRendererDelegate.java
+++ b/parser/src/main/java/org/hibernate/hql/ast/spi/SingleEntityQueryRendererDelegate.java
@@ -71,16 +71,19 @@ public abstract class SingleEntityQueryRendererDelegate<Q, R> implements QueryRe
 
 	protected Class<?> targetType;
 
-	protected final SingleEntityQueryBuilder<Q> builder;
-
 	protected PropertyPath propertyPath;
+
+	protected final SingleEntityQueryBuilder<Q> builder;
 
 	protected final List<String> projections = new ArrayList<String>();
 
 	/**
 	 * Persister space: keep track of aliases and entity names.
 	 */
-	private final Map<String, String> aliasToEntityType = new HashMap<String, String>();
+	protected final Map<String, String> aliasToEntityType = new HashMap<String, String>();
+	protected final Map<String, PropertyPath> aliasToPropertyPath = new HashMap<String, PropertyPath>();
+
+	protected String alias;
 
 	private final Map<String, Object> namedParameters;
 
@@ -116,6 +119,13 @@ public abstract class SingleEntityQueryRendererDelegate<Q, R> implements QueryRe
 		}
 	}
 
+	public void registerEmbeddedAlias(String alias, PropertyPath propertyPath) {
+		PropertyPath put = aliasToPropertyPath.put( alias, propertyPath );
+		if ( put != null ) {
+			throw new UnsupportedOperationException( "Alias reuse currently not supported: alias " + alias + " already assigned to type " + put );
+		}
+	}
+
 	private void setTargetType(String entityName) {
 		Class<?> targetedType = entityNames.getClassFromName( entityName );
 		if ( targetedType == null ) {
@@ -135,17 +145,12 @@ public abstract class SingleEntityQueryRendererDelegate<Q, R> implements QueryRe
 
 	@Override
 	public boolean isUnqualifiedPropertyReference() {
-		return true; // TODO - very likely always true for our supported use cases
+		return true;
 	}
 
 	@Override
 	public boolean isPersisterReferenceAlias() {
-		if ( aliasToEntityType.size() == 1 ) {
-			return true; // should be safe
-		}
-		else {
-			throw new UnsupportedOperationException( "Unexpected use case: not implemented yet?" );
-		}
+		return aliasToEntityType.containsKey( alias );
 	}
 
 	@Override
@@ -154,7 +159,8 @@ public abstract class SingleEntityQueryRendererDelegate<Q, R> implements QueryRe
 			Tree assosiationFetchTree,
 			Tree propertyFetchTree,
 			Tree alias) {
-		throw new UnsupportedOperationException( "Not yet implemented" );
+		status = Status.DEFINING_FROM;
+		this.alias = alias.getText();
 	}
 
 	@Override
@@ -170,6 +176,7 @@ public abstract class SingleEntityQueryRendererDelegate<Q, R> implements QueryRe
 	@Override
 	public void popStrategy() {
 		status = null;
+		this.alias = null;
 	}
 
 	@Override
@@ -228,13 +235,15 @@ public abstract class SingleEntityQueryRendererDelegate<Q, R> implements QueryRe
 
 	private void addComparisonPredicate(String comparativePredicate, Type comparisonType) {
 		Object comparisonValue = fromNamedQuery( comparativePredicate );
-		builder.addComparisonPredicate( propertyPath.getNodeNamesWithoutAlias(), comparisonType, comparisonValue );
+		List<String> property = resolveAlias( propertyPath );
+		builder.addComparisonPredicate( property, comparisonType, comparisonValue );
 	}
 
 	@Override
 	public void predicateIn(List<String> list) {
 		List<Object> values = fromNamedQuery( list );
-		builder.addInPredicate( propertyPath.getNodeNamesWithoutAlias(), values );
+		List<String> property = resolveAlias( propertyPath );
+		builder.addInPredicate( property, values );
 	}
 
 	@Override
@@ -242,18 +251,21 @@ public abstract class SingleEntityQueryRendererDelegate<Q, R> implements QueryRe
 		Object lowerComparisonValue = fromNamedQuery( lower );
 		Object upperComparisonValue = fromNamedQuery( upper );
 
-		builder.addRangePredicate( propertyPath.getNodeNamesWithoutAlias(), lowerComparisonValue, upperComparisonValue );
+		List<String> property = resolveAlias( propertyPath );
+		builder.addRangePredicate( property, lowerComparisonValue, upperComparisonValue );
 	}
 
 	@Override
 	public void predicateLike(String patternValue, Character escapeCharacter) {
 		Object pattern = fromNamedQuery( patternValue );
-		builder.addLikePredicate( propertyPath.getNodeNamesWithoutAlias(), (String) pattern, escapeCharacter );
+		List<String> property = resolveAlias( propertyPath );
+		builder.addLikePredicate( property, (String) pattern, escapeCharacter );
 	}
 
 	@Override
 	public void predicateIsNull() {
-		builder.addIsNullPredicate( propertyPath.getNodeNamesWithoutAlias() );
+		List<String> property = resolveAlias( propertyPath );
+		builder.addIsNullPredicate( property );
 	}
 
 	@Override
@@ -297,4 +309,36 @@ public abstract class SingleEntityQueryRendererDelegate<Q, R> implements QueryRe
 
 	@Override
 	public abstract R getResult();
+
+	protected List<String> resolveAlias(PropertyPath path) {
+		if ( path.getFirstNode().isAlias() ) {
+			String alias = path.getFirstNode().getName();
+			if ( aliasToEntityType.containsKey( alias ) ) {
+				// Alias for entity
+				return path.getNodeNamesWithoutAlias();
+			}
+			else if ( aliasToPropertyPath.containsKey( alias ) ) {
+				// Alias for embedded
+				PropertyPath propertyPath = aliasToPropertyPath.get( alias );
+				List<String> resolvedAlias = resolveAlias( propertyPath );
+				resolvedAlias.addAll( path.getNodeNamesWithoutAlias() );
+				return resolvedAlias;
+			}
+			else {
+				// Alias not found
+				aliasNotFound( alias );
+			}
+		}
+		// It does not start with an alias
+		return path.getNodeNamesWithoutAlias();
+	}
+
+	@Override
+	public void registerJoinAlias(Tree alias, PropertyPath path) {
+		if ( !aliasToPropertyPath.containsKey( alias ) ) {
+			aliasToPropertyPath.put( alias.getText(), path );
+		}
+	}
+
+	public abstract void aliasNotFound(String alias);
 }

--- a/parser/src/main/java/org/hibernate/hql/internal/logging/Log.java
+++ b/parser/src/main/java/org/hibernate/hql/internal/logging/Log.java
@@ -55,4 +55,7 @@ public interface Log extends BasicLogger {
 
 	@Message(id = 6, value = "The query %s is not valid; Found unconsumed token(s): %s.")
 	ParsingException getInvalidQuerySyntaxDueToUnconsumedTokensException(String query, String unconsumedTokens);
+
+	@Message(id = 7, value = "Unknown alias: %s.")
+	ParsingException getUnknownAliasException(String unknownAlias);
 }

--- a/parser/src/test/java/org/hibernate/hql/test/tree/ParsingTest.java
+++ b/parser/src/test/java/org/hibernate/hql/test/tree/ParsingTest.java
@@ -20,7 +20,7 @@
  */
 package org.hibernate.hql.test.tree;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.antlr.runtime.ANTLRStringStream;
 import org.antlr.runtime.CommonTokenStream;

--- a/parser/src/test/java/org/hibernate/hql/test/tree/ParsingTest.java
+++ b/parser/src/test/java/org/hibernate/hql/test/tree/ParsingTest.java
@@ -21,7 +21,6 @@
 package org.hibernate.hql.test.tree;
 
 import org.junit.Assert;
-
 import org.antlr.runtime.ANTLRStringStream;
 import org.antlr.runtime.CommonTokenStream;
 import org.antlr.runtime.RecognitionException;
@@ -85,6 +84,20 @@ public class ParsingTest {
 		//generated alias:
 		assertTreeParsed( null, "from com.acme.EntityName e where e.name = 'Jack Daniel''s Old No. 7'",
 			"(QUERY (QUERY_SPEC (SELECT_FROM (from (PERSISTER_SPACE (ENTITY_PERSISTER_REF com.acme.EntityName e))) (SELECT (SELECT_LIST (SELECT_ITEM e)))) (where (= (PATH (. e name)) (CONST_STRING_VALUE Jack Daniel's Old No. 7)))))");
+	}
+
+	@Test
+	public void testJoinOnEmbedded() {
+		//generated alias:
+		assertTreeParsed( null, " SELECT e.author.name  FROM IndexedEntity e JOIN e.contactDetails d  JOIN e.alternativeContactDetails a WHERE d.address.postCode='EA123' AND a.email='mail@mail.af'",
+			"(QUERY (QUERY_SPEC (SELECT_FROM (FROM (PERSISTER_SPACE (ENTITY_PERSISTER_REF IndexedEntity e) (property-join INNER d (PATH (. e contactDetails))) (property-join INNER a (PATH (. e alternativeContactDetails))))) (SELECT (SELECT_LIST (SELECT_ITEM (PATH (. (. e author) name)))))) (WHERE (AND (= (PATH (. (. d address) postCode)) (CONST_STRING_VALUE EA123)) (= (PATH (. a email)) (CONST_STRING_VALUE mail@mail.af))))))");
+	}
+
+	@Test
+	public void testProjectionOnEmbeddedAndUnquilifiedProperties() {
+		//generated alias:
+		assertTreeParsed( null, " SELECT name, text, e.author.name  FROM IndexedEntity e JOIN e.contactDetails d",
+			"(QUERY (QUERY_SPEC (SELECT_FROM (FROM (PERSISTER_SPACE (ENTITY_PERSISTER_REF IndexedEntity e) (property-join INNER d (PATH (. e contactDetails))))) (SELECT (SELECT_LIST (SELECT_ITEM (PATH name)) (SELECT_ITEM (PATH text)) (SELECT_ITEM (PATH (. (. e author) name))))))))");
 	}
 
 	private void assertTreeParsed(ParserContext context, String input, String treeExpectation) {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HQLPARSER-53

This patch will enable the support of join operation.

I've chenged the parsed and now the sub-tree related to a join is the following:

```
(property-join INNER a (PATH (. e author)))))
```

instead of 

```
(property-join INNER a (PROPERTY_REFERENCE (. e author)))))
```

This way I can register the property path and the alias via the new method `delegate.registerJoinAlias(Tree alias, PropertyPath propertyPath)`

This method is invoked when the new rule *joinPropertyReference* in GeneratedHQLResolver.g and QueryRenderer.g is called.

@gunnarmorling, @Sanne  It seems to pass all the test but let me know if I missed something