### PR TITLE
[1.0.x] HQLPARSER-63 Add an optional FieldBridgeProvider param to LuceneProcessingChain.buildProcessingChainForClassBasedEntities()

### DIFF
--- a/lucene/src/main/java/org/hibernate/hql/lucene/LuceneProcessingChain.java
+++ b/lucene/src/main/java/org/hibernate/hql/lucene/LuceneProcessingChain.java
@@ -102,13 +102,23 @@ public class LuceneProcessingChain implements AstProcessingChain<LuceneQueryPars
 		 * @return a Lucene processing chain for parsing queries targeted at Java class-based entities
 		 */
 		public LuceneProcessingChain buildProcessingChainForClassBasedEntities() {
-			ClassBasedLucenePropertyHelper propertyHelper = new ClassBasedLucenePropertyHelper( searchFactory, entityNames );
+			return buildProcessingChainForClassBasedEntities( null );
+		}
+
+		/**
+		 * Builds a processing chain for parsing queries targeted at Java class-based entities.
+		 *
+		 * @param fieldBridgeProvider a custom FieldBridgeProvider to be used instead of the defaults
+		 * @return a Lucene processing chain for parsing queries targeted at Java class-based entities
+		 */
+		public LuceneProcessingChain buildProcessingChainForClassBasedEntities(FieldBridgeProvider fieldBridgeProvider) {
+			ClassBasedLucenePropertyHelper propertyHelper = new ClassBasedLucenePropertyHelper( searchFactory, entityNames, fieldBridgeProvider );
 
 			QueryResolverProcessor resolverProcessor = new QueryResolverProcessor(
 					new ClassBasedLuceneQueryResolverDelegate( propertyHelper, entityNames )
 					);
 
-			LuceneQueryRendererDelegate rendererDelegate = getRendererDelegate( searchFactory, null, entityNames, namedParameters, propertyHelper );
+			LuceneQueryRendererDelegate rendererDelegate = getRendererDelegate( searchFactory, fieldBridgeProvider, entityNames, namedParameters, propertyHelper );
 
 			QueryRendererProcessor rendererProcessor = new QueryRendererProcessor( rendererDelegate );
 

--- a/lucene/src/main/java/org/hibernate/hql/lucene/internal/builder/ClassBasedLucenePropertyHelper.java
+++ b/lucene/src/main/java/org/hibernate/hql/lucene/internal/builder/ClassBasedLucenePropertyHelper.java
@@ -26,8 +26,10 @@ import java.util.List;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.Field.Index;
 import org.hibernate.hql.ast.spi.EntityNamesResolver;
+import org.hibernate.hql.internal.util.Strings;
 import org.hibernate.hql.lucene.internal.logging.Log;
 import org.hibernate.hql.lucene.internal.logging.LoggerFactory;
+import org.hibernate.hql.lucene.spi.FieldBridgeProvider;
 import org.hibernate.search.bridge.FieldBridge;
 import org.hibernate.search.engine.metadata.impl.EmbeddedTypeMetadata;
 import org.hibernate.search.engine.metadata.impl.PropertyMetadata;
@@ -46,14 +48,24 @@ public class ClassBasedLucenePropertyHelper extends LucenePropertyHelper {
 
 	private final SearchFactoryIntegrator searchFactory;
 	private final EntityNamesResolver entityNames;
+	private final FieldBridgeProvider fieldBridgeProvider;
 
 	public ClassBasedLucenePropertyHelper(SearchFactoryIntegrator searchFactory, EntityNamesResolver entityNames) {
+		this( searchFactory, entityNames, null );
+	}
+
+	public ClassBasedLucenePropertyHelper(SearchFactoryIntegrator searchFactory, EntityNamesResolver entityNames, FieldBridgeProvider fieldBridgeProvider) {
 		this.searchFactory = searchFactory;
 		this.entityNames = entityNames;
+		this.fieldBridgeProvider = fieldBridgeProvider;
 	}
 
 	@Override
 	public FieldBridge getFieldBridge(String entityType, List<String> propertyPath) {
+		if ( fieldBridgeProvider != null ) {
+			return fieldBridgeProvider.getFieldBridge( entityType, Strings.join( propertyPath, "." ) );
+		}
+
 		Class<?> type = getType( entityType );
 		String[] propertyPathAsArray = propertyPath.toArray( new String[propertyPath.size()] );
 
@@ -64,6 +76,11 @@ public class ClassBasedLucenePropertyHelper extends LucenePropertyHelper {
 		}
 
 		PropertyMetadata metadata = getLeafTypeMetadata( type, propertyPathAsArray ).getPropertyMetadataForProperty( propertyPathAsArray[propertyPathAsArray.length - 1] );
+
+		if ( metadata == null ) {
+			// not a leaf
+			return null;
+		}
 
 		// TODO Consider properties with several fields
 		return metadata.getFieldMetadata().iterator().next().getFieldBridge();

--- a/lucene/src/main/java/org/hibernate/hql/lucene/internal/builder/ClassBasedLucenePropertyHelper.java
+++ b/lucene/src/main/java/org/hibernate/hql/lucene/internal/builder/ClassBasedLucenePropertyHelper.java
@@ -72,7 +72,7 @@ public class ClassBasedLucenePropertyHelper extends LucenePropertyHelper {
 	private Class<?> getType(String typeName) {
 		Class<?> type = entityNames.getClassFromName( typeName );
 		if ( type == null ) {
-			throw new IllegalStateException( "Unknown entity name " + type );
+			throw new IllegalStateException( "Unknown entity name " + typeName );
 		}
 
 		return type;

--- a/parser/src/test/java/org/hibernate/hql/test/tree/ParsingTest.java
+++ b/parser/src/test/java/org/hibernate/hql/test/tree/ParsingTest.java
@@ -20,7 +20,7 @@
  */
 package org.hibernate.hql.test.tree;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.antlr.runtime.ANTLRStringStream;
 import org.antlr.runtime.CommonTokenStream;


### PR DESCRIPTION
Unfortunately this needs to be backported to 1.0.x too.

jira: https://hibernate.atlassian.net/browse/HQLPARSER-63

